### PR TITLE
Move Route / to bottom

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,10 +15,10 @@ function App() {
     <div className="wrapper">
       <BrowserRouter>
         <Switch>
-          <Route path="/">
+          <Route path="/profile">
             <Profile />
           </Route>
-          <Route path="/profile">
+          <Route path="/">
             <Profile />
           </Route>
         </Switch>


### PR DESCRIPTION
From https://reactrouter.com/web/guides/quick-start
A <Switch> looks through its children <Route>s and renders the first one that matches the current URL

Fixed the route /profile will never render due to all route will match with / at the first